### PR TITLE
[ENDER-14645] Enable setting the HttpOnly acookie attribute

### DIFF
--- a/src/bowser/model/Response.java
+++ b/src/bowser/model/Response.java
@@ -87,10 +87,10 @@ public class Response {
   }
 
   public Response cookie(String key, String value, int expiry, TimeUnit units) {
-    return cookie(key, value, expiry, units, "");
+    return cookie(key, value, expiry, units, "", false);
   }
 
-  public Response cookie(String key, String value, int expiry, TimeUnit units, String domain) {
+  public Response cookie(String key, String value, int expiry, TimeUnit units, String domain, boolean httpOnly) {
     Cookie cookie = new Cookie(key, value);
     if (!domain.isEmpty()) {
       cookie.setDomain(domain);
@@ -100,6 +100,8 @@ public class Response {
     } else {
       cookie.setExpiry((int) TimeUnit.SECONDS.convert(expiry, units));
     }
+    // HttpOnly attribute forbids JavaScript from accessing the cookie
+    cookie.setProtected(httpOnly);
     return cookie(cookie);
   }
 


### PR DESCRIPTION
### Issue
https://ender-1337.atlassian.net/browse/ENDER-14645

### Description
As part of our SOC2 Complince we need to ensure that our authentication token can not be read by any third party javascript libraries we use in the front-end.

This PR will allow us to set the HttpOnly cookie attribute which will prevent all JavaScript from accessing our authentication cookie.
Which is the only effective way to block 3rd party JS libs from accessing the auth cookie asside from not using cookies at all.